### PR TITLE
５つの画面を作成

### DIFF
--- a/lib/constant/dummy.dart
+++ b/lib/constant/dummy.dart
@@ -1,0 +1,16 @@
+import '../model/reservation.dart';
+
+class Dummy {
+  static final Reservation reservation = Reservation(
+      date: "20231228",
+      time: "9:30",
+      clientCD: 111111,
+      clientName: "A社",
+      deliveryPort: "C-1");
+
+  static final List<Reservation> reservationList =
+      List.generate(100, (index) => reservation);
+
+  static const String mailHint = "mail@wentz-design.com";
+  static const String passHint = "password";
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,6 @@
+import 'package:berth_app/ui/login_page.dart';
+import 'package:berth_app/ui/search_arrival_page.dart';
+import 'package:berth_app/util/size_config.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -10,6 +13,8 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    SizeConfig().init(context);
+
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
@@ -24,92 +29,7 @@ class MyApp extends StatelessWidget {
         // is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: LoginPage(),
     );
   }
 }

--- a/lib/model/reservation.dart
+++ b/lib/model/reservation.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/cupertino.dart';
+
+@immutable
+class Reservation {
+  Reservation({
+    required this.date,
+    required this.time,
+    required this.clientCD,
+    required this.clientName,
+    required this.deliveryPort,
+  });
+  String date;
+  String time;
+  int clientCD;
+  String clientName;
+  String deliveryPort;
+}

--- a/lib/ui/confirm_data_from_csv_page.dart
+++ b/lib/ui/confirm_data_from_csv_page.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+
+import '../constant/dummy.dart';
+import '../model/reservation.dart';
+import '../util/size_config.dart';
+
+class ConfirmDataFromCsvPage extends StatelessWidget {
+  ConfirmDataFromCsvPage({super.key});
+  final labels = List<DataColumn>.generate(
+      5, (int index) => DataColumn(label: Text("ラベル$index")),
+      growable: false);
+
+  final values = List<DataRow>.generate(20, (int index) {
+    return DataRow(cells: [
+      DataCell(Text("山田$index郎")),
+      const DataCell(Text("男性")),
+      const DataCell(Text("2000/10/30")),
+      const DataCell(Text("東京都港区")),
+      const DataCell(Text("会社員")),
+    ]);
+  }, growable: false);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(),
+      body: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: SizeConfig.blockSizeHorizontal * 20,
+          vertical: SizeConfig.blockSizeVertical * 10,
+        ),
+        child: Column(
+          children: [
+            InputedDataList(
+              datas: Dummy.reservationList,
+            ),
+            SizedBox(height: SizeConfig.blockSizeVertical * 10),
+            Text("上記${Dummy.reservationList.length}件のデータを登録します"),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _ConfirmButton(
+                  title: "キャンセル",
+                  onPressed: () {},
+                ),
+                _ConfirmButton(
+                  title: "登録する",
+                  isRegistration: true,
+                  onPressed: () {},
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ConfirmButton extends StatelessWidget {
+  const _ConfirmButton({
+    super.key,
+    required this.title,
+    required this.onPressed,
+    this.isRegistration = false,
+  });
+  final String title;
+  final bool isRegistration;
+  final VoidCallback onPressed;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: SizeConfig.blockSizeVertical * 5,
+      width: SizeConfig.blockSizeHorizontal * 10,
+      margin: EdgeInsets.symmetric(
+        horizontal: SizeConfig.blockSizeHorizontal * 1,
+        vertical: SizeConfig.blockSizeVertical * 3,
+      ),
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: isRegistration ? Colors.orange : Colors.grey,
+        ),
+        onPressed: onPressed,
+        child: Text(title),
+      ),
+    );
+  }
+}
+
+class InputedDataList extends StatelessWidget {
+  const InputedDataList({
+    super.key,
+    required this.datas,
+  });
+  final List<Reservation> datas;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        children: [
+          _listHeader(),
+          Expanded(
+            child: ListView.builder(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                itemCount: datas.length,
+                itemBuilder: (contex, index) {
+                  return Container(
+                    padding: EdgeInsets.symmetric(
+                        vertical: SizeConfig.blockSizeVertical * 1),
+                    decoration: BoxDecoration(
+                        border: Border(
+                      bottom: BorderSide(color: Colors.grey),
+                    )),
+                    child: Row(
+                      children: [
+                        buildCellData(datas[index].date),
+                        buildCellData(datas[index].time),
+                        buildCellData(datas[index].clientCD.toString()),
+                        buildCellData(datas[index].clientName),
+                        buildCellData(datas[index].deliveryPort),
+                      ],
+                    ),
+                  );
+                }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _listHeader() {
+    final List<String> headerLabels = ["日付", "時間", "取引先CD", "取引先名", "納品口"];
+    final List<Widget> headerList = List.generate(
+        headerLabels.length,
+        (index) => Expanded(
+                child: Center(
+              child: Text(headerLabels[index],
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+            )));
+
+    return Container(
+        decoration: const BoxDecoration(
+            border:
+                Border(bottom: BorderSide(width: 2.0, color: Colors.black))),
+        child: ListTile(title: Row(children: headerList)));
+  }
+
+  Expanded buildCellData(String title) {
+    return Expanded(child: Center(child: Text(title)));
+  }
+}

--- a/lib/ui/import_csv_page.dart
+++ b/lib/ui/import_csv_page.dart
@@ -1,0 +1,112 @@
+import 'package:berth_app/ui/confirm_data_from_csv_page.dart';
+import 'package:berth_app/util/size_config.dart';
+import 'package:flutter/material.dart';
+
+class ImportCSVPage extends StatelessWidget {
+  const ImportCSVPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(),
+      body: Padding(
+        padding: EdgeInsets.symmetric(
+            horizontal: SizeConfig.blockSizeHorizontal * 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text("CSVをインポートしてください"),
+            SizedBox(height: SizeConfig.blockSizeVertical * 2),
+            _ImportCsvWidget(),
+            SizedBox(height: SizeConfig.blockSizeVertical * 2),
+            _RegistrationButton()
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RegistrationButton extends StatelessWidget {
+  const _RegistrationButton({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.center,
+      child: SizedBox(
+        height: SizeConfig.blockSizeVertical * 5,
+        width: SizeConfig.blockSizeHorizontal * 10,
+        child: OutlinedButton(
+          style: OutlinedButton.styleFrom(
+            padding: EdgeInsets.zero,
+            backgroundColor: Colors.orange,
+            foregroundColor: Colors.black,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+          ),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => ConfirmDataFromCsvPage()),
+            );
+          },
+          child: Text("登録する"),
+        ),
+      ),
+    );
+  }
+}
+
+class _ImportCsvWidget extends StatelessWidget {
+  const _ImportCsvWidget({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: SizeConfig.blockSizeVertical * 5,
+      child: Row(
+        children: [
+          Expanded(
+            flex: 3,
+            child: Container(
+              alignment: Alignment.center,
+              height: double.infinity,
+              margin:
+                  EdgeInsets.only(right: SizeConfig.blockSizeHorizontal * 2),
+              decoration: BoxDecoration(
+                border: Border.all(),
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text("入荷指定データ.CSV"),
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: SizedBox(
+              height: double.infinity,
+              child: OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  padding: EdgeInsets.zero,
+                  backgroundColor: Colors.black12,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                onPressed: () {},
+                child: Text("ファイルを選択"),
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/login_page.dart
+++ b/lib/ui/login_page.dart
@@ -1,0 +1,82 @@
+import 'package:berth_app/constant/dummy.dart';
+import 'package:berth_app/ui/select_task_page.dart';
+import 'package:flutter/material.dart';
+
+import '../util/size_config.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(),
+      body: Padding(
+        padding: EdgeInsets.symmetric(
+            horizontal: SizeConfig.blockSizeHorizontal * 10,
+            vertical: SizeConfig.blockSizeVertical * 10),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _LoginForm(
+              title: "メールアドレス",
+              hint: Dummy.mailHint,
+            ),
+            _LoginForm(
+              title: "パスワード",
+              hint: Dummy.passHint,
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blueAccent,
+                  foregroundColor: Colors.white),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const SelectTaskPage()),
+                );
+              },
+              child: Text("ログイン"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LoginForm extends StatelessWidget {
+  _LoginForm({super.key, required this.title, required this.hint});
+  final String title;
+  final String hint;
+  final TextStyle essentialTextStyle = TextStyle(color: Colors.red);
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: SizeConfig.blockSizeVertical * 5),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text.rich(TextSpan(children: [
+            TextSpan(text: title),
+            TextSpan(text: "　(必須)", style: essentialTextStyle)
+          ])),
+          SizedBox(
+            height: SizeConfig.blockSizeVertical * 2,
+          ),
+          TextField(
+            decoration: InputDecoration(
+                hintText: hint,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 0)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/search_arrival_page.dart
+++ b/lib/ui/search_arrival_page.dart
@@ -1,0 +1,114 @@
+/* 時間制定確認画面 */
+
+import 'package:berth_app/constant/dummy.dart';
+import 'package:berth_app/ui/confirm_data_from_csv_page.dart';
+import 'package:berth_app/util/size_config.dart';
+import 'package:flutter/material.dart';
+
+class SearchArrivalPage extends StatelessWidget {
+  const SearchArrivalPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      backgroundColor: Colors.white,
+      body: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: SizeConfig.blockSizeHorizontal * 20,
+          vertical: SizeConfig.blockSizeVertical * 5,
+        ),
+        child: Column(
+          children: [
+            Container(
+              height: SizeConfig.blockSizeVertical * 30,
+              padding:
+                  EdgeInsets.only(bottom: SizeConfig.blockSizeVertical * 3),
+              child: Row(
+                children: [
+                  _FilterTextFields(),
+                  Expanded(
+                      flex: 2,
+                      child: Align(
+                        alignment: Alignment.bottomCenter,
+                        child: Container(
+                          height: SizeConfig.blockSizeVertical * 10,
+                          width: double.infinity,
+                          padding: EdgeInsets.only(
+                              left: SizeConfig.blockSizeHorizontal * 5),
+                          child: OutlinedButton(
+                            style: OutlinedButton.styleFrom(
+                              padding: EdgeInsets.zero,
+                              backgroundColor: Colors.blueAccent,
+                              foregroundColor: Colors.white,
+                              shape: RoundedRectangleBorder(
+                                side: BorderSide(width: 0),
+                                borderRadius: BorderRadius.circular(30),
+                              ),
+                            ),
+                            onPressed: () {},
+                            child: Text("表示する"),
+                          ),
+                        ),
+                      ))
+                ],
+              ),
+            ),
+            InputedDataList(
+              datas: Dummy.reservationList,
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterTextFields extends StatelessWidget {
+  const _FilterTextFields({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      flex: 3,
+      child: Column(
+        children: [
+          _buildTextField(title: "日付"),
+          _buildTextField(title: "時間"),
+          _buildTextField(title: "納品口"),
+          _buildTextField(title: "取引先CD"),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTextField({required title}) {
+    return Expanded(
+      child: Container(
+        width: double.infinity,
+        child: Row(
+          children: [
+            Expanded(
+              flex: 1,
+              child: Text(title),
+            ),
+            Expanded(
+              flex: 3,
+              child: TextField(
+                decoration: InputDecoration(
+                    border: OutlineInputBorder(
+                      borderSide: const BorderSide(color: Colors.grey),
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 10, vertical: 0)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/select_task_page.dart
+++ b/lib/ui/select_task_page.dart
@@ -1,0 +1,81 @@
+import 'package:berth_app/ui/search_arrival_page.dart';
+import 'package:berth_app/util/size_config.dart';
+import 'package:flutter/material.dart';
+
+import 'import_csv_page.dart';
+
+class SelectTaskPage extends StatelessWidget {
+  const SelectTaskPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(),
+      body: Container(
+        width: SizeConfig.screenWidth,
+        padding: EdgeInsets.symmetric(
+          horizontal: SizeConfig.blockSizeHorizontal * 10,
+          vertical: SizeConfig.blockSizeVertical * 10,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            _TaskButton(
+              title: "時間指定画面（CSV一括）",
+              isInputCsv: true,
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const ImportCSVPage()),
+                );
+              },
+            ),
+            _TaskButton(
+              title: "時間指定確認画面",
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const SearchArrivalPage()),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TaskButton extends StatelessWidget {
+  const _TaskButton({
+    super.key,
+    required this.title,
+    required this.onPressed,
+    this.isInputCsv = false,
+  });
+  final String title;
+  final VoidCallback onPressed;
+  final bool isInputCsv;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding:
+          EdgeInsets.symmetric(vertical: SizeConfig.blockSizeHorizontal * 3),
+      child: SizedBox(
+        height: SizeConfig.blockSizeVertical * 10,
+        width: SizeConfig.blockSizeHorizontal * 40,
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+              backgroundColor: isInputCsv ? Colors.orange : Colors.blue,
+              foregroundColor: Colors.white),
+          onPressed: onPressed,
+          child: Text(title),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/util/custom_color.dart
+++ b/lib/util/custom_color.dart
@@ -1,0 +1,8 @@
+import 'dart:ui';
+
+class CustomColor{
+
+  static Color appBarTheme = const Color(0xFFf8f8ff);
+  static Color listBorderColor = const Color(0xFFdfdfdf);
+  static Color lavender = const Color(0xFFefeff4);
+}

--- a/lib/util/size_config.dart
+++ b/lib/util/size_config.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class SizeConfig {
+  static late MediaQueryData _mediaQueryData;
+  static late double screenWidth;
+  static late double screenHeight;
+  static late double blockSizeHorizontal;
+  static late double blockSizeVertical;
+
+  void init(BuildContext context) {
+    _mediaQueryData = MediaQuery.of(context);
+    screenWidth = _mediaQueryData.size.width;
+    screenHeight = _mediaQueryData.size.height;
+    blockSizeHorizontal = screenWidth / 100;
+    blockSizeVertical = screenHeight / 100;
+  }
+}


### PR DESCRIPTION
## 対応内容
- ログイン画面、業務選択画面、時間指定選択画面、入力データ確認画面、時間制定確認画面の５つの画面を作成。
## 確認方法
- エミュレーター、もしくは実機で起動する。
## UI
<img width="500" alt="スクリーンショット 2024-01-22 16 46 31" src="https://github.com/arsYamashita/berth_app/assets/152578761/ec1fbbf3-45d0-4597-867d-8183c7c933fb">
<img width="500" alt="スクリーンショット 2024-01-22 16 46 35" src="https://github.com/arsYamashita/berth_app/assets/152578761/cb7701ea-b205-41f9-96b1-e01b5d1f1ecb">
<img width="500" alt="スクリーンショット 2024-01-22 16 46 38" src="https://github.com/arsYamashita/berth_app/assets/152578761/7d6e0ed5-eb4a-402e-8d10-7bb84240de6f">
<img width="500" alt="スクリーンショット 2024-01-22 16 46 43" src="https://github.com/arsYamashita/berth_app/assets/152578761/0d1838d7-f8ca-460b-8852-c8177035d1a4">
<img width="500" alt="スクリーンショット 2024-01-22 16 46 49" src="https://github.com/arsYamashita/berth_app/assets/152578761/d40cc8ff-11ff-4529-b7eb-2386aafb6c11">



