### PR TITLE
CSVファイルのインポート機能を追加

### DIFF
--- a/lib/controller/import_csv_controller.dart
+++ b/lib/controller/import_csv_controller.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:berth_app/ui/confirm_data_from_csv_page.dart';
+import 'package:berth_app/util/csv_reader.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+part 'import_csv_controller.freezed.dart';
+
+@freezed
+class ImportCsvState with _$ImportCsvState {
+  const factory ImportCsvState({
+    @Default("") String fileName,
+  }) = _ImportCsvState;
+}
+
+final importCsvProvider =
+    StateNotifierProvider.autoDispose<ImportCsvController, ImportCsvState>(
+        (ref) => ImportCsvController());
+
+class ImportCsvController extends StateNotifier<ImportCsvState> {
+  ImportCsvController() : super(const ImportCsvState());
+
+  FilePickerResult? csvData;
+
+  void pickFile(BuildContext context) async {
+    // CSVをインポートする処理
+    FilePickerResult? picResult = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['csv'],
+      withData: true,
+    );
+    if (picResult == null) {
+      return;
+    }
+    csvData = picResult;
+    _inputFileName(picResult.files.single.name);
+  }
+
+  void readCsvData() {
+    // CSVデータを読み込む処理
+    if (this.csvData == null) {
+      return;
+    }
+    final _csvBytes = this.csvData!.files.single.bytes;
+    final _csvText = utf8.decode(_csvBytes!);
+
+    final csvResult = CsvReader().getCsvDataResult(_csvText);
+    print('CSV: ${csvResult.csvData}, error: ${csvResult.errorMessages}');
+  }
+
+  void _inputFileName(String fileName) {
+    state = state.copyWith(fileName: fileName);
+  }
+}

--- a/lib/controller/import_csv_controller.freezed.dart
+++ b/lib/controller/import_csv_controller.freezed.dart
@@ -1,0 +1,135 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'import_csv_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ImportCsvState {
+  String get fileName => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ImportCsvStateCopyWith<ImportCsvState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ImportCsvStateCopyWith<$Res> {
+  factory $ImportCsvStateCopyWith(
+          ImportCsvState value, $Res Function(ImportCsvState) then) =
+      _$ImportCsvStateCopyWithImpl<$Res, ImportCsvState>;
+  @useResult
+  $Res call({String fileName});
+}
+
+/// @nodoc
+class _$ImportCsvStateCopyWithImpl<$Res, $Val extends ImportCsvState>
+    implements $ImportCsvStateCopyWith<$Res> {
+  _$ImportCsvStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? fileName = null,
+  }) {
+    return _then(_value.copyWith(
+      fileName: null == fileName
+          ? _value.fileName
+          : fileName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ImportCsvStateImplCopyWith<$Res>
+    implements $ImportCsvStateCopyWith<$Res> {
+  factory _$$ImportCsvStateImplCopyWith(_$ImportCsvStateImpl value,
+          $Res Function(_$ImportCsvStateImpl) then) =
+      __$$ImportCsvStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String fileName});
+}
+
+/// @nodoc
+class __$$ImportCsvStateImplCopyWithImpl<$Res>
+    extends _$ImportCsvStateCopyWithImpl<$Res, _$ImportCsvStateImpl>
+    implements _$$ImportCsvStateImplCopyWith<$Res> {
+  __$$ImportCsvStateImplCopyWithImpl(
+      _$ImportCsvStateImpl _value, $Res Function(_$ImportCsvStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? fileName = null,
+  }) {
+    return _then(_$ImportCsvStateImpl(
+      fileName: null == fileName
+          ? _value.fileName
+          : fileName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ImportCsvStateImpl implements _ImportCsvState {
+  const _$ImportCsvStateImpl({this.fileName = ""});
+
+  @override
+  @JsonKey()
+  final String fileName;
+
+  @override
+  String toString() {
+    return 'ImportCsvState(fileName: $fileName)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ImportCsvStateImpl &&
+            (identical(other.fileName, fileName) ||
+                other.fileName == fileName));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, fileName);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ImportCsvStateImplCopyWith<_$ImportCsvStateImpl> get copyWith =>
+      __$$ImportCsvStateImplCopyWithImpl<_$ImportCsvStateImpl>(
+          this, _$identity);
+}
+
+abstract class _ImportCsvState implements ImportCsvState {
+  const factory _ImportCsvState({final String fileName}) = _$ImportCsvStateImpl;
+
+  @override
+  String get fileName;
+  @override
+  @JsonKey(ignore: true)
+  _$$ImportCsvStateImplCopyWith<_$ImportCsvStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/controller/login_controller.freezed.dart
+++ b/lib/controller/login_controller.freezed.dart
@@ -12,7 +12,7 @@ part of 'login_controller.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$LoginState {

--- a/lib/ui/import_csv_page.dart
+++ b/lib/ui/import_csv_page.dart
@@ -1,6 +1,13 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:berth_app/controller/import_csv_controller.dart';
 import 'package:berth_app/ui/confirm_data_from_csv_page.dart';
 import 'package:berth_app/util/size_config.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class ImportCSVPage extends StatelessWidget {
   const ImportCSVPage({super.key});
@@ -31,7 +38,9 @@ class ImportCSVPage extends StatelessWidget {
 class _RegistrationButton extends StatelessWidget {
   const _RegistrationButton({
     super.key,
+    this.onPressed,
   });
+  final onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -40,23 +49,23 @@ class _RegistrationButton extends StatelessWidget {
       child: SizedBox(
         height: SizeConfig.blockSizeVertical * 5,
         width: SizeConfig.blockSizeHorizontal * 10,
-        child: OutlinedButton(
-          style: OutlinedButton.styleFrom(
-            padding: EdgeInsets.zero,
-            backgroundColor: Colors.orange,
-            foregroundColor: Colors.black,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(10),
+        child: Consumer(builder: (context, ref, _) {
+          final notifier = ref.read(importCsvProvider.notifier);
+          return OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              padding: EdgeInsets.zero,
+              backgroundColor: Colors.orange,
+              foregroundColor: Colors.black,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
             ),
-          ),
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => ConfirmDataFromCsvPage()),
-            );
-          },
-          child: Text("登録する"),
-        ),
+            onPressed: () {
+              notifier.readCsvData();
+            },
+            child: Text("登録する"),
+          );
+        }),
       ),
     );
   }
@@ -71,42 +80,49 @@ class _ImportCsvWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       height: SizeConfig.blockSizeVertical * 5,
-      child: Row(
-        children: [
-          Expanded(
-            flex: 3,
-            child: Container(
-              alignment: Alignment.center,
-              height: double.infinity,
-              margin:
-                  EdgeInsets.only(right: SizeConfig.blockSizeHorizontal * 2),
-              decoration: BoxDecoration(
-                border: Border.all(),
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(10),
-              ),
-              child: Text("入荷指定データ.CSV"),
-            ),
-          ),
-          Expanded(
-            flex: 1,
-            child: SizedBox(
-              height: double.infinity,
-              child: OutlinedButton(
-                style: OutlinedButton.styleFrom(
-                  padding: EdgeInsets.zero,
-                  backgroundColor: Colors.black12,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10),
-                  ),
+      child: Consumer(builder: (context, ref, _) {
+        final fileName =
+            ref.watch(importCsvProvider.select((value) => value.fileName));
+        final notifier = ref.watch(importCsvProvider.notifier);
+        return Row(
+          children: [
+            Expanded(
+              flex: 3,
+              child: Container(
+                alignment: Alignment.center,
+                height: double.infinity,
+                margin:
+                    EdgeInsets.only(right: SizeConfig.blockSizeHorizontal * 2),
+                decoration: BoxDecoration(
+                  border: Border.all(),
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(10),
                 ),
-                onPressed: () {},
-                child: Text("ファイルを選択"),
+                child: Text(fileName),
               ),
             ),
-          )
-        ],
-      ),
+            Expanded(
+              flex: 1,
+              child: SizedBox(
+                height: double.infinity,
+                child: OutlinedButton(
+                  style: OutlinedButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    backgroundColor: Colors.black12,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  onPressed: () async {
+                    notifier.pickFile(context);
+                  },
+                  child: Text("ファイルを選択"),
+                ),
+              ),
+            )
+          ],
+        );
+      }),
     );
   }
 }

--- a/lib/util/csv_reader.dart
+++ b/lib/util/csv_reader.dart
@@ -1,0 +1,69 @@
+class CsvReader {
+  final CsvDataResult _csvData = CsvDataResult();
+  CsvDataResult getCsvDataResult(String csvText) {
+    //改行ごとに行を格納する
+    List<String> lines = csvText.split('\n');
+    //空行を削除
+    lines.removeWhere((line) => line.trim().isEmpty);
+    //csvファイルが空の場合
+    if (lines.isEmpty) {
+      _csvData.addErrorMessage('CSVファイルが空です');
+      return _csvData;
+    }
+    for (int i = 0; i < lines.length; i++) {
+      final csvRowItems = lines[i].split(',');
+      //項目ごとのバリデーション
+      _csvValidation(i + 1, csvRowItems);
+      _csvData.addCsvData(csvRowItems);
+    }
+    return _csvData;
+  }
+
+  //項目ごとのバリデーション
+  void _csvValidation(int count, List<String> csvRowitems) {
+    String errorMessage = '';
+
+    if (csvRowitems.length != 5) {
+      errorMessage += 'CSVのフォーマットが不正です';
+      _csvData.addErrorMessage(errorMessage);
+      return;
+    }
+    //拠点CDが四桁の数字でない場合
+    if (csvRowitems[0].length != 4 || int.tryParse(csvRowitems[0]) == null) {
+      errorMessage += '拠点CDが不正です。\n';
+    }
+    //日付がYYYY/MM/DD形式でない場合
+    if (!RegExp(r'^\d{4}/\d{2}/\d{2}$').hasMatch(csvRowitems[1])) {
+      errorMessage += '日付が不正です。\n';
+    }
+    //時間がHH:MM形式でない場合
+    if (!RegExp(r'^\d{2}:\d{2}$').hasMatch(csvRowitems[2])) {
+      errorMessage += '時間が不正です。\n';
+    }
+    //取引先CDが6桁の数字でない場合
+    if (csvRowitems[3].length != 6 || int.tryParse(csvRowitems[3]) == null) {
+      errorMessage += '取引先CDが不正です。\n';
+    }
+    //納品口の情報
+    //errorMessageが空でない場合、エラーメッセージを追加
+    if (errorMessage.isNotEmpty) {
+      _csvData.addErrorMessage('${count}行目：\n${errorMessage}');
+    }
+  }
+}
+
+//エラー内容とCSVデータの各行を保持するクラス
+class CsvDataResult {
+  final List<List<String>> _csvData = [];
+  final List<String> _errorMessages = [];
+  void addCsvData(List<String> csvData) {
+    _csvData.add(csvData);
+  }
+
+  void addErrorMessage(String errorMessage) {
+    _errorMessages.add(errorMessage);
+  }
+
+  get csvData => _csvData;
+  get errorMessages => _errorMessages;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   json_annotation: ^4.8.1
   firebase_auth: ^4.16.0
+  file_picker: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 対応
- CSVファイルを選択したのち、登録ボタンを押すとCSVファイルの内容を読み込み、配列に格納。
- 項目ごとに適切な値かチェック。不適切な場合はエラーメッセージを配列に格納。

## 確認方法
- CSVインポート画面より、「ファイルを選択」からCSVファイルを選択。
- 「登録」ボタンを押すとコンソールに読み込んだ内容が表示される。

## テスト用ファイル
- テスト用にCSVファイルを作成。
[successful.csv](https://github.com/arsYamashita/berth_app/files/14217202/successful.csv)
[blank.csv](https://github.com/arsYamashita/berth_app/files/14217203/blank.csv)
[fairue.csv](https://github.com/arsYamashita/berth_app/files/14217204/fairue.csv)
