### PR TITLE
インポートしたCSVの内容を登録画面に表示

### DIFF
--- a/lib/controller/confirm_data_controller.dart
+++ b/lib/controller/confirm_data_controller.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../util/csv_reader.dart';
+
+final confirmDataProvider = StateNotifierProvider.autoDispose<
+    ConfirmDataController,
+    Future<CsvDataResult>>((ref) => throw UnimplementedError());
+
+final confirmDataProviderFamily = StateNotifierProvider.autoDispose
+    .family<ConfirmDataController, Future<CsvDataResult>, String>(
+        (ref, csvData) {
+  return ConfirmDataController(csvData: csvData);
+});
+
+class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
+  ConfirmDataController({required this.csvData})
+      : super(CsvReader().getCsvDataResult(csvData) as Future<CsvDataResult>);
+  final String csvData;
+
+  void readCSVData() {
+    // CSVデータを読み込む処理
+    final csvResult = CsvReader().getCsvDataResult(csvData);
+    state = csvResult;
+  }
+
+  void inputCsvData(String csvData) {}
+}

--- a/lib/controller/import_csv_controller.dart
+++ b/lib/controller/import_csv_controller.dart
@@ -24,7 +24,7 @@ class ImportCsvController extends StateNotifier<ImportCsvState> {
 
   FilePickerResult? csvData;
 
-  void pickFile(BuildContext context) async {
+  void pickFile() async {
     // CSVをインポートする処理
     FilePickerResult? picResult = await FilePicker.platform.pickFiles(
       type: FileType.custom,
@@ -38,16 +38,24 @@ class ImportCsvController extends StateNotifier<ImportCsvState> {
     _inputFileName(picResult.files.single.name);
   }
 
-  void readCsvData() {
+  String getCsvText() {
+    if (this.csvData == null) {
+      return "";
+    }
+    final _csvBytes = this.csvData!.files.single.bytes;
+    return utf8.decode(_csvBytes!);
+  }
+
+  Future<CsvDataResult> readCsvData() {
     // CSVデータを読み込む処理
     if (this.csvData == null) {
-      return;
+      return Future.value(CsvDataResult());
     }
     final _csvBytes = this.csvData!.files.single.bytes;
     final _csvText = utf8.decode(_csvBytes!);
-
     final csvResult = CsvReader().getCsvDataResult(_csvText);
-    print('CSV: ${csvResult.csvData}, error: ${csvResult.errorMessages}');
+
+    return csvResult;
   }
 
   void _inputFileName(String fileName) {

--- a/lib/ui/import_csv_page.dart
+++ b/lib/ui/import_csv_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:berth_app/controller/confirm_data_controller.dart';
 import 'package:berth_app/controller/import_csv_controller.dart';
 import 'package:berth_app/ui/confirm_data_from_csv_page.dart';
 import 'package:berth_app/util/size_config.dart';
@@ -61,7 +62,14 @@ class _RegistrationButton extends StatelessWidget {
               ),
             ),
             onPressed: () {
-              notifier.readCsvData();
+              if (notifier.getCsvText().isEmpty) {
+                return;
+              }
+              Navigator.of(context).push(MaterialPageRoute(
+                  builder: (context) => ProviderScope(overrides: [
+                        confirmDataProvider.overrideWithProvider(
+                            confirmDataProviderFamily(notifier.getCsvText()))
+                      ], child: ConfirmDataFromCsvPage())));
             },
             child: Text("登録する"),
           );
@@ -114,7 +122,7 @@ class _ImportCsvWidget extends StatelessWidget {
                     ),
                   ),
                   onPressed: () async {
-                    notifier.pickFile(context);
+                    notifier.pickFile();
                   },
                   child: Text("ファイルを選択"),
                 ),

--- a/lib/ui/search_arrival_page.dart
+++ b/lib/ui/search_arrival_page.dart
@@ -54,9 +54,9 @@ class SearchArrivalPage extends StatelessWidget {
                 ],
               ),
             ),
-            InputedDataList(
-              datas: Dummy.reservationList,
-            )
+            // InputedDataList(
+            //   datas: Dummy.reservationList,
+            // )
           ],
         ),
       ),

--- a/lib/util/csv_reader.dart
+++ b/lib/util/csv_reader.dart
@@ -1,69 +1,120 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class CsvReader {
-  final CsvDataResult _csvData = CsvDataResult();
-  CsvDataResult getCsvDataResult(String csvText) {
+  final CsvDataResult _csvDataResult = CsvDataResult();
+
+  Future<CsvDataResult> getCsvDataResult(String csvText) async {
     //改行ごとに行を格納する
     List<String> lines = csvText.split('\n');
     //空行を削除
     lines.removeWhere((line) => line.trim().isEmpty);
     //csvファイルが空の場合
     if (lines.isEmpty) {
-      _csvData.addErrorMessage('CSVファイルが空です');
-      return _csvData;
+      _csvDataResult.setErrorMessage('CSVファイルが空です');
+      return _csvDataResult;
     }
     for (int i = 0; i < lines.length; i++) {
-      final csvRowItems = lines[i].split(',');
+      List<String> csvRowItems = lines[i].split(',');
       //項目ごとのバリデーション
-      _csvValidation(i + 1, csvRowItems);
-      _csvData.addCsvData(csvRowItems);
+      if (await _csvValidation(i + 1, csvRowItems)) {
+        return _csvDataResult;
+      }
+      //userCodeからuserNameを取得
+      final userDocSnapshot = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(csvRowItems[3])
+          .get();
+      final userName = userDocSnapshot['name'];
+
+      final csvData = CsvData(
+        branchCode: csvRowItems[0],
+        date: csvRowItems[1],
+        time: csvRowItems[2],
+        userCode: csvRowItems[3],
+        deliveryPort: csvRowItems[4],
+        userName: userName,
+      );
+
+      _csvDataResult.addCsvData(csvData);
     }
-    return _csvData;
+    return _csvDataResult;
   }
 
   //項目ごとのバリデーション
-  void _csvValidation(int count, List<String> csvRowitems) {
-    String errorMessage = '';
+  Future<bool> _csvValidation(int count, List<String> csvRowItems) async {
+    final errorMessage = StringBuffer();
 
-    if (csvRowitems.length != 5) {
-      errorMessage += 'CSVのフォーマットが不正です';
-      _csvData.addErrorMessage(errorMessage);
-      return;
+    final branchCode = csvRowItems[0];
+    final userCode = csvRowItems[3];
+
+    final branchDocSnapshot = await FirebaseFirestore.instance
+        .collection('branch')
+        .doc(branchCode)
+        .get();
+    final userDocSnapshot = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(userCode)
+        .get();
+
+    if (csvRowItems.length != 5) {
+      errorMessage.write('$count行目：項目数が不正です。');
+      _csvDataResult.setErrorMessage(errorMessage.toString());
+      return true;
     }
-    //拠点CDが四桁の数字でない場合
-    if (csvRowitems[0].length != 4 || int.tryParse(csvRowitems[0]) == null) {
-      errorMessage += '拠点CDが不正です。\n';
+
+    if (branchCode.length != 4 || int.tryParse(branchCode) == null) {
+      errorMessage.write('拠点CDが不正です。');
+    } else if (!branchDocSnapshot.exists) {
+      errorMessage.write('拠点CDが存在しません。');
+    } else if (!RegExp(r'^\d{4}/\d{2}/\d{2}$').hasMatch(csvRowItems[1])) {
+      errorMessage.write('日付が不正です。');
+    } else if (!RegExp(r'^\d{2}:\d{2}$').hasMatch(csvRowItems[2])) {
+      errorMessage.write('時間が不正です。');
+    } else if (userCode.length != 9 || int.tryParse(userCode) == null) {
+      errorMessage.write('取引先CDが不正です。');
+    } else if (!userDocSnapshot.exists) {
+      errorMessage.write('取引先CDが存在しません。');
     }
-    //日付がYYYY/MM/DD形式でない場合
-    if (!RegExp(r'^\d{4}/\d{2}/\d{2}$').hasMatch(csvRowitems[1])) {
-      errorMessage += '日付が不正です。\n';
-    }
-    //時間がHH:MM形式でない場合
-    if (!RegExp(r'^\d{2}:\d{2}$').hasMatch(csvRowitems[2])) {
-      errorMessage += '時間が不正です。\n';
-    }
-    //取引先CDが6桁の数字でない場合
-    if (csvRowitems[3].length != 6 || int.tryParse(csvRowitems[3]) == null) {
-      errorMessage += '取引先CDが不正です。\n';
-    }
-    //納品口の情報
-    //errorMessageが空でない場合、エラーメッセージを追加
     if (errorMessage.isNotEmpty) {
-      _csvData.addErrorMessage('${count}行目：\n${errorMessage}');
+      _csvDataResult.setErrorMessage('$count行目: ${errorMessage.toString()}');
+      return true;
     }
+
+    return false;
   }
 }
 
 //エラー内容とCSVデータの各行を保持するクラス
 class CsvDataResult {
-  final List<List<String>> _csvData = [];
-  final List<String> _errorMessages = [];
-  void addCsvData(List<String> csvData) {
+  final List<CsvData> _csvData = [];
+  String _errorMessages = "";
+  void addCsvData(CsvData csvData) {
     _csvData.add(csvData);
   }
 
-  void addErrorMessage(String errorMessage) {
-    _errorMessages.add(errorMessage);
+  void setErrorMessage(String errorMessage) {
+    _errorMessages = errorMessage;
   }
 
   get csvData => _csvData;
   get errorMessages => _errorMessages;
+}
+
+//csv格納用のクラス
+class CsvData {
+  final String branchCode;
+  final String date;
+  final String time;
+  final String userCode;
+  final String userName;
+  final String deliveryPort;
+
+  CsvData({
+    required this.branchCode,
+    required this.date,
+    required this.time,
+    required this.userCode,
+    required this.userName,
+    required this.deliveryPort,
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   json_annotation: ^4.8.1
   firebase_auth: ^4.16.0
   file_picker: ^6.1.1
+  cloud_firestore: ^4.15.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 対応
- 読み込んだCSVを確認画面でテーブル表示で確認できるよう表示
- 読み取りエラーが起きるファイルをインポートした場合はエラー文を表示。

## UI
<img width="700" alt="成功画面" src="https://github.com/arsYamashita/berth_app/assets/152578761/6eed550d-4a3b-4fbc-a8bf-5e47ef5a5b3d">

<img width="700" alt="エラー画面" src="https://github.com/arsYamashita/berth_app/assets/152578761/74c6c385-c7b1-4b21-9936-447d9376a49d">

## テスト用ファイル

[fairue.csv](https://github.com/arsYamashita/berth_app/files/14277586/fairue.csv)
[successful.csv](https://github.com/arsYamashita/berth_app/files/14277585/successful.csv)

