### PR TITLE
予約登録時にダイアログを表示

### DIFF
--- a/lib/controller/confirm_data_controller.dart
+++ b/lib/controller/confirm_data_controller.dart
@@ -56,7 +56,7 @@ class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
       for (int i = 0; i < data.csvData.length; i++) {
         final uuid = Uuid().v4();
         try {
-          mFirestore.collection('reservation').doc(uuid).set({
+          await mFirestore.collection('reservation').doc(uuid).set({
             'branchCode': data.csvData[i].branchCode,
             'branchName': data.csvData[i].branchName,
             'date': data.csvData[i].date,

--- a/lib/controller/confirm_data_controller.dart
+++ b/lib/controller/confirm_data_controller.dart
@@ -3,8 +3,12 @@ import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:uuid/uuid.dart';
 import '../util/csv_reader.dart';
+
+//ダイアログ用プロバイダー
+final dialogStateProvider = StateProvider<AsyncValue<void>>(
+  (_) => const AsyncValue.data(null),
+);
 
 final confirmDataProvider =
     StateNotifierProvider<ConfirmDataController, Future<CsvDataResult>>(
@@ -12,13 +16,14 @@ final confirmDataProvider =
 
 final confirmDataProviderFamily = StateNotifierProvider.family<
     ConfirmDataController, Future<CsvDataResult>, String>((ref, csvData) {
-  return ConfirmDataController(csvData: csvData);
+  return ConfirmDataController(ref: ref, csvData: csvData);
 });
 
 class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
-  ConfirmDataController({required this.csvData})
+  ConfirmDataController({required this.ref, required this.csvData})
       : super(CsvReader().getCsvDataResult(csvData) as Future<CsvDataResult>);
   final String csvData;
+  final Ref ref;
 
   void readCSVData() {
     // CSVデータを読み込む処理
@@ -26,27 +31,50 @@ class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
     state = csvResult;
   }
 
+  void testShowDialog() async {
+    ref.read(dialogStateProvider.notifier).state = await AsyncValue.loading();
+    Future.delayed(const Duration(seconds: 2), () async {
+      ref.read(dialogStateProvider.notifier).state =
+          await AsyncValue.guard(() async {
+        // ここで実際にログイン処理を非同期で行う
+      });
+    });
+  }
+
   //データをFirebaseに登録
   void registerData() {
-    state.then((data) {
+    state.then((data) async {
       if (data.errorMessages.isNotEmpty) {
         return;
       }
 
       final mFirestore = FirebaseFirestore.instance;
+      //ローディングさせる
+      ref.read(dialogStateProvider.notifier).state =
+          await const AsyncValue.loading();
       //for文でデータを登録
       for (int i = 0; i < data.csvData.length; i++) {
         final uuid = Uuid().v4();
-        mFirestore.collection('reservation').doc(uuid).set({
-          'branchCode': data.csvData[i].branchCode,
-          'branchName': data.csvData[i].branchName,
-          'date': data.csvData[i].date,
-          'time': data.csvData[i].time,
-          'userCode': data.csvData[i].userCode,
-          'deliveryPort': data.csvData[i].deliveryPort,
-          'userName': data.csvData[i].userName,
-        }).then((value) => sendFCMNotification());
+        try {
+          mFirestore.collection('reservation').doc(uuid).set({
+            'branchCode': data.csvData[i].branchCode,
+            'branchName': data.csvData[i].branchName,
+            'date': data.csvData[i].date,
+            'time': data.csvData[i].time,
+            'userCode': data.csvData[i].userCode,
+            'deliveryPort': data.csvData[i].deliveryPort,
+            'userName': data.csvData[i].userName,
+          }).onError(
+              (error, stackTrace) => throw Exception([error, stackTrace]));
+        } catch (e, s) {
+          ref.read(dialogStateProvider.notifier).state =
+              await AsyncValue.error(e, s);
+          return;
+        }
       }
+      //全データ登録したことを通知
+      ref.read(dialogStateProvider.notifier).state =
+          await const AsyncValue.data(null);
     });
   }
 

--- a/lib/ui/confirm_data_from_csv_page.dart
+++ b/lib/ui/confirm_data_from_csv_page.dart
@@ -73,6 +73,13 @@ class ConfirmDataFromCsvPage extends StatelessWidget {
                             title: "登録する",
                             isRegistration: true,
                             onPressed: () {
+                              // notifier.registerData();
+                              showDialog(
+                                  context: context,
+                                  barrierDismissible: false,
+                                  builder: (context) {
+                                    return _RegistrationDialog();
+                                  });
                               notifier.registerData();
                             },
                           ),
@@ -190,5 +197,39 @@ class InputedDataList extends StatelessWidget {
 
   Expanded buildCellData(String title) {
     return Expanded(child: Center(child: Text(title)));
+  }
+}
+
+class _RegistrationDialog extends ConsumerWidget {
+  const _RegistrationDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, ref) {
+    final dialogState = ref.watch(dialogStateProvider);
+
+    return AlertDialog(
+      title: Text(dialogState.isLoading ? "登録中" : "登録完了"),
+      content: ref.watch(dialogStateProvider).when(
+        data: (value) {
+          return const Text("登録されました。");
+        },
+        loading: () {
+          return const SizedBox(width: 100, child: LinearProgressIndicator());
+        },
+        error: (error, stack) {
+          return Text("エラーが発生しました: ${error.toString()}");
+        },
+      ),
+      actions: [
+        dialogState.isLoading
+            ? SizedBox()
+            : ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                child: const Text("OK"),
+              ),
+      ],
+    );
   }
 }


### PR DESCRIPTION
## 対応
- アプリからFirestoreにデータ登録するとダイアログが非同期で表示される。
- 全て登録するまでローディング（プログレスバー）が表示される。

## UI

<img width="754" alt="スクリーンショット 2024-02-22 15 08 06" src="https://github.com/arsYamashita/berth_app/assets/152578761/0a5dafc3-4e0d-4663-9786-f969d08b9487">
