### PR TITLE
データ登録後の二重登録を防ぐ

### DIFF
--- a/lib/controller/confirm_data_controller.dart
+++ b/lib/controller/confirm_data_controller.dart
@@ -32,16 +32,6 @@ class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
     state = csvResult;
   }
 
-  void testShowDialog() async {
-    ref.read(dialogStateProvider.notifier).state = await AsyncValue.loading();
-    Future.delayed(const Duration(seconds: 2), () async {
-      ref.read(dialogStateProvider.notifier).state =
-          await AsyncValue.guard(() async {
-        // ここで実際にログイン処理を非同期で行う
-      });
-    });
-  }
-
   //データをFirebaseに登録
   void registerData() {
     state.then((data) async {
@@ -96,7 +86,6 @@ class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
       'Authorization': 'Bearer $token',
       'Content-Type': 'application/json',
     };
-
 
     // 送信するメッセージデータ
     final messageData = {

--- a/lib/ui/confirm_data_from_csv_page.dart
+++ b/lib/ui/confirm_data_from_csv_page.dart
@@ -67,7 +67,9 @@ class ConfirmDataFromCsvPage extends StatelessWidget {
                         children: [
                           _ConfirmButton(
                             title: "キャンセル",
-                            onPressed: () {},
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
                           ),
                           _ConfirmButton(
                             title: "登録する",
@@ -226,7 +228,10 @@ class _RegistrationDialog extends ConsumerWidget {
             ? SizedBox()
             : ElevatedButton(
                 onPressed: () {
-                  Navigator.of(context).pop();
+                  // ダイアログを閉じて前の画面に戻る
+                  Navigator.pop(context);
+                  // ダイアログが閉じられた後に前の画面に戻る
+                  Navigator.pop(context);
                 },
                 child: const Text("OK"),
               ),


### PR DESCRIPTION
## 対応
- データ登録後に表示されるOKボタンを押すと前の画面に遷移する
- ダイアログの領域外をクリックしてもダイアログを閉じない