### PR TITLE
予約登録時にデバイスに通知を送信

### DIFF
--- a/lib/model/ReservationNotification.dart
+++ b/lib/model/ReservationNotification.dart
@@ -1,0 +1,17 @@
+class ReservationNotification {
+  //constructor
+  ReservationNotification({
+    required this.userCode,
+  });
+  final String userCode;
+  List<String> reservationIDs = [];
+  List<String> fcmTokens = [];
+
+  void addReservationID(String id) {
+    reservationIDs.add(id);
+  }
+
+  void addFcmToken(List<String> token) {
+    fcmTokens = token;
+  }
+}


### PR DESCRIPTION
## 対応
- 予約登録時にデバイスに通知をする。
- 同一会社の予約なら複数回に分けるのではなく、まとめて通知する。
- 通知受信側は予約IDをFCMのdata[reservations]から取得できる。

## 確認方法
- モバイル側で実機でログインし、ログインしたユーザーコードが含まれているcsvファイルをインポート、登録すると通知が確認できる。

## 検証用ファイル
[success.csv](https://github.com/arsYamashita/berth_app/files/14416378/success.csv)
