### PR TITLE
検索結果の初期表示が空白になるよう修正

### DIFF
--- a/lib/ui/search_arrival_page.dart
+++ b/lib/ui/search_arrival_page.dart
@@ -132,6 +132,7 @@ class _SearchArrivalPageState extends State<SearchArrivalPage> {
   late List<DocumentSnapshot> _currentResults;
   late int _currentPage;
   late int _totalPages;
+  bool isInitialState = true;
   static const int _itemsPerPage = 100;
 
   @override
@@ -427,6 +428,7 @@ class _SearchArrivalPageState extends State<SearchArrivalPage> {
                       );
                       // _searchResultsと_totalPagesを更新
                       setState(() {
+                        isInitialState = false;
                         _searchResults = results;
                         _currentPage = 1; // ページ数を1にリセット
                         _newUpdateResults(); // ここで_updateResultsを呼び出す
@@ -449,8 +451,8 @@ class _SearchArrivalPageState extends State<SearchArrivalPage> {
               color: Colors.grey,
             ),
             _searchResults.isEmpty
-                ? const Center(
-                    child: Text('No results found.'),
+                ? Center(
+                    child: Text(isInitialState ? '' : 'No results found'),
                   )
                 : DeliverySearchResultTable(
                     key: _searchResultTableKey,


### PR DESCRIPTION
## 対応
納品指定確認画面の検索結果欄の初期表示と結果無しの状態が同じで違い分かりづらいため、初期表示時、空白になるよう修正
## UI
<img width="867" alt="スクリーンショット 2024-03-29 17 29 12" src="https://github.com/arsYamashita/berth_app/assets/152578761/ebd849a1-2043-46eb-a505-dfe7ba9ab62a">
