### PR TITLE
ログインの認証失敗時のスナックバーの文言を変更

### DIFF
--- a/lib/controller/login_controller.dart
+++ b/lib/controller/login_controller.dart
@@ -30,10 +30,16 @@ class LoginController extends StateNotifier<LoginState> {
     try {
       await FirebaseAuth.instance.signInWithEmailAndPassword(
           email: state.email, password: state.password);
-          
+
       return "ログインしました";
     } on FirebaseAuthException catch (e) {
-      return e.code;
+      String errorMessage = '';
+      if (e.code == 'invalid-email') {
+        errorMessage = 'メールアドレスが正しくありません';
+      } else if (e.code == 'invalid-credential') {
+        errorMessage = 'ログインできません';
+      }
+      return errorMessage;
     }
   }
 }


### PR DESCRIPTION
## 対応
- ログイン画面でメールアドレスの形式が正しくないで、ログインボタンを押下した時に「メールアドレスが正しくありません」というメッセージを表示
- ログインボタンを押下した時に認証ができずログインできなかった時に、「ログインできません」というメッセージを表示