### PR TITLE
CSVデータ登録時に全ての予約データにisNewフラグを設定

### DIFF
--- a/lib/controller/confirm_data_controller.dart
+++ b/lib/controller/confirm_data_controller.dart
@@ -72,7 +72,7 @@ class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
             'userCode': data.csvData[i].userCode,
             'deliveryPort': data.csvData[i].deliveryPort,
             'userName': data.csvData[i].userName,
-            'isNew': false,
+            'isNew': true,
           }).onError(
               (error, stackTrace) => throw Exception([error, stackTrace]));
         } catch (e, s) {

--- a/lib/controller/confirm_data_controller.dart
+++ b/lib/controller/confirm_data_controller.dart
@@ -72,6 +72,7 @@ class ConfirmDataController extends StateNotifier<Future<CsvDataResult>> {
             'userCode': data.csvData[i].userCode,
             'deliveryPort': data.csvData[i].deliveryPort,
             'userName': data.csvData[i].userName,
+            'isNew': false,
           }).onError(
               (error, stackTrace) => throw Exception([error, stackTrace]));
         } catch (e, s) {


### PR DESCRIPTION
## 対応
- FIrestoreへ予約データを登録時、isNewフラグを設定する（初期値false)