### PR TITLE
開始日と終了日以外の項目のフィルターが機能しない不具合を修正

### DIFF
--- a/lib/controller/search_arrival_controller.dart
+++ b/lib/controller/search_arrival_controller.dart
@@ -31,21 +31,6 @@ class DeliverySearchViewModel extends ChangeNotifier {
 
   List<DocumentSnapshot> get searchResults => searchResult;
 
-  Future<void> searchDeliveries() async {
-    if (_deliveryStartDate != null && _deliveryEndDate != null) {
-      searchResult = await _service.searchDeliveries(
-        deliveryStartDate: _deliveryStartDate.toString(),
-        deliveryEndDate: _deliveryEndDate.toString(),
-        branchCode: _branchCode,
-        deliveryStartTime: _deliveryStartTime,
-        deliveryEndTime: _deliveryEndTime,
-        userCode: _userCode,
-        deliveryPort: _deliveryPort,
-      );
-    }
-    notifyListeners();
-  }
-
   void pickDeliveryDate(BuildContext context, {bool isStart = true}) async {
     final DateTime? date = await showDatePicker(
       context: context,
@@ -89,6 +74,7 @@ class DeliverySearchViewModel extends ChangeNotifier {
       searchResult = results;
       _currentPage = 1; // ページ数を1にリセット
       newUpdateResults(); // ここで_updateResultsを呼び出す
+      print(_branchCode);
     } else {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text("開始日と終了日は必須項目です")));

--- a/lib/ui/search_arrival_page.dart
+++ b/lib/ui/search_arrival_page.dart
@@ -96,7 +96,7 @@ class SearchArrivalPage extends HookConsumerWidget {
             const SizedBox(height: 16.0),
             const Divider(
               height: 50,
-              thickness: 5,
+              // thickness: 5,
               indent: 0,
               endIndent: 0,
               color: Colors.grey,
@@ -140,7 +140,7 @@ class FilterInputForm extends StatelessWidget {
           vertical: 0,
         ),
       ),
-      onChanged: (value) => onChanged,
+      onChanged: onChanged,
     );
 
     return isUserCdForm


### PR DESCRIPTION
## 対応
-　納品指定確認画面で、開始日と終了日以外の項目で絞り込みが反映されない不具合を修正
## 原因
- TextFieldのonchangeプロパティに渡す引数が誤っていた。